### PR TITLE
removed superbuild-gazebo from `devel` and `release` workflows

### DIFF
--- a/.github/workflows/devel.yml
+++ b/.github/workflows/devel.yml
@@ -20,4 +20,4 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           repository: ${{ github.repository }}
           event-type: cron_trigger
-          client-payload: '{"version": "master", "type": "cron_trigger", "img_list": "superbuild superbuild-icubhead superbuild-icubhead-withuser superbuild-gazebo superbuild-ros2"}'
+          client-payload: '{"version": "master", "type": "cron_trigger", "img_list": "superbuild superbuild-icubhead superbuild-icubhead-withuser superbuild-ros2"}'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,5 +71,5 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           repository: ${{ env.REPOSITORY_NAME }}
           event-type: repository_trigger
-          client-payload: '{"version": "${{ steps.get_version.outputs.version }}", "type": "repository_trigger", "img_list": "superbuild superbuild-icubhead superbuild-icubhead-withuser superbuild-gazebo superbuild-ros2"}'
+          client-payload: '{"version": "${{ steps.get_version.outputs.version }}", "type": "repository_trigger", "img_list": "superbuild superbuild-icubhead superbuild-icubhead-withuser superbuild-ros2"}'
           


### PR DESCRIPTION
Since we deprecated the gazebo images, I removed the compilation from `devel `and `release `workflows.