### PR TITLE
Bugfix/cleanup registry

### DIFF
--- a/.github/workflows/build-arm64.yml
+++ b/.github/workflows/build-arm64.yml
@@ -24,6 +24,7 @@ jobs:
         image:
           - superbuild-nvdia-arm-raicam
           # Add more images here
+        tag: [Stable, Unstable]
       fail-fast: false
     
     permissions:
@@ -51,22 +52,35 @@ jobs:
           REPOSITORY_OWNER="${{ github.repository_owner }}"
           IMAGE_NAME="${{ env.REGISTRY }}/$REPOSITORY_OWNER/${{ matrix.image }}"
           VERSION="${{ github.ref_name }}"
-          [[ "$VERSION" == "master" || "$VERSION" == "main" ]] && VERSION="latest"
+          TAG="$(echo "-${{ matrix.tag }}" | tr '[:upper:]' '[:lower:]')"
           
           echo "image=$IMAGE_NAME" >> $GITHUB_OUTPUT
           echo "version=$VERSION" >> $GITHUB_OUTPUT
-          echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+          echo "tag=$TAG" >> $GITHUB_OUTPUT
+          echo "metadata=$(date +'%d/%m/%Y_%H:%M:%S')" >> $GITHUB_OUTPUT
 
       - name: Build and push ARM64 image
+        id: build-push
         uses: docker/build-push-action@v5
         with:
           context: ./dockerfile_images/basic/${{ matrix.image }}
           file: ./dockerfile_images/basic/${{ matrix.image }}/Dockerfile
           push: ${{ github.event.inputs.push_to_registry == 'true' }}
           tags: |
-            ${{ steps.meta.outputs.image }}:${{ steps.meta.outputs.version }}
-            ${{ steps.meta.outputs.image }}:${{ steps.meta.outputs.sha_short }}
-          cache-from: type=registry,ref=${{ steps.meta.outputs.image }}:buildcache
-          cache-to: type=registry,ref=${{ steps.meta.outputs.image }}:buildcache,mode=max
+            ${{ steps.meta.outputs.image }}:${{ steps.meta.outputs.version }}${{ steps.meta.outputs.tag }}_sources
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
           build-args: |
             START_IMG=nvcr.io/nvidia/l4t-jetpack:r36.4.0
+            release=${{ steps.meta.outputs.version }}
+            sbtag=${{ matrix.tag }}
+            metadata=${{ steps.meta.outputs.metadata }}
+
+      - name: Clean untagged Ghcr.io images
+        if: ${{ github.event.inputs.push_to_registry == 'true' && steps.build-push.outcome == 'success' }}
+        uses: actions/delete-package-versions@v5
+        with:
+          package-name: ${{ matrix.image }}
+          package-type: container
+          min-versions-to-keep: 0
+          delete-only-untagged-versions: 'true'

--- a/.github/workflows/build-arm64.yml
+++ b/.github/workflows/build-arm64.yml
@@ -8,12 +8,13 @@ on:
         required: false
         default: 'false'
   schedule:
-    # The job runs every two weeks
-      - cron: '0 0 1,15 * *'
+    # The job runs once a month
+      - cron: '0 0 1 * *'
 
 env:
   REGISTRY: ghcr.io
   REGISTRY_USERNAME: ${{ github.actor }}
+  PUSH_TO_REGISTRY: ${{ github.event_name == 'schedule' || inputs.push_to_registry == 'true' }}
 
 jobs:
   build-arm64:
@@ -40,7 +41,7 @@ jobs:
 
       - name: Log in to Container Registry
         uses: docker/login-action@v3
-        if: github.event.inputs.push_to_registry == 'true'
+        if: env.PUSH_TO_REGISTRY == 'true'
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ env.REGISTRY_USERNAME }}
@@ -65,11 +66,9 @@ jobs:
         with:
           context: ./dockerfile_images/basic/${{ matrix.image }}
           file: ./dockerfile_images/basic/${{ matrix.image }}/Dockerfile
-          push: ${{ github.event.inputs.push_to_registry == 'true' }}
+          push: ${{ env.PUSH_TO_REGISTRY == 'true' }}
           tags: |
             ${{ steps.meta.outputs.image }}:${{ steps.meta.outputs.version }}${{ steps.meta.outputs.tag }}_sources
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
           build-args: |
             START_IMG=nvcr.io/nvidia/l4t-jetpack:r36.4.0
             release=${{ steps.meta.outputs.version }}
@@ -77,7 +76,8 @@ jobs:
             metadata=${{ steps.meta.outputs.metadata }}
 
       - name: Clean untagged Ghcr.io images
-        if: ${{ github.event.inputs.push_to_registry == 'true' && steps.build-push.outcome == 'success' }}
+        if: ${{ env.PUSH_TO_REGISTRY == 'true' && steps.build-push.outcome == 'success' }}
+        continue-on-error: true
         uses: actions/delete-package-versions@v5
         with:
           package-name: ${{ matrix.image }}

--- a/.github/workflows/cleanup-ghcr-untagged.yml
+++ b/.github/workflows/cleanup-ghcr-untagged.yml
@@ -1,0 +1,120 @@
+name: Cleanup GHCR untagged images
+
+on:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Print untagged package versions without deleting them'
+        required: true
+        default: 'true'
+        type: choice
+        options:
+          - 'true'
+          - 'false'
+      package_prefix:
+        description: 'Optional package name prefix to clean instead of the default repo image packages'
+        required: false
+        default: ''
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clean untagged GHCR package versions
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          OWNER: ${{ github.repository_owner }}
+          OWNER_TYPE: ${{ github.event.repository.owner.type }}
+          ACTOR: ${{ github.actor }}
+          REPOSITORY: ${{ github.event.repository.name }}
+          DRY_RUN: ${{ inputs.dry_run }}
+          PACKAGE_PREFIX: ${{ inputs.package_prefix }}
+          ARM64_PACKAGES: superbuild-nvdia-arm-raicam
+        run: |
+          set -euo pipefail
+
+          if [ "$OWNER_TYPE" = "Organization" ]; then
+            api_base="/orgs/$OWNER"
+          elif [ "$OWNER" = "$ACTOR" ]; then
+            api_base="/user"
+          else
+            api_base="/users/$OWNER"
+          fi
+
+          should_clean_package() {
+            local package_name="$1"
+
+            if [ -n "$PACKAGE_PREFIX" ]; then
+              [[ "$package_name" == "$PACKAGE_PREFIX"* ]]
+              return
+            fi
+
+            if [[ "$package_name" == "$REPOSITORY/cd_"* ]]; then
+              return 0
+            fi
+
+            for arm64_package in $ARM64_PACKAGES; do
+              if [ "$package_name" = "$arm64_package" ]; then
+                return 0
+              fi
+            done
+
+            return 1
+          }
+
+          total_packages=0
+          matched_packages=0
+          untagged_versions=0
+          deleted_versions=0
+
+          while IFS= read -r package_name; do
+            total_packages=$((total_packages + 1))
+
+            if ! should_clean_package "$package_name"; then
+              continue
+            fi
+
+            matched_packages=$((matched_packages + 1))
+            encoded_package=$(jq -rn --arg value "$package_name" '$value|@uri')
+            versions_endpoint="$api_base/packages/container/$encoded_package/versions"
+
+            echo "Inspecting package: $package_name"
+
+            while IFS=$'\t' read -r version_id version_name; do
+              if [ -z "$version_id" ]; then
+                continue
+              fi
+
+              untagged_versions=$((untagged_versions + 1))
+              echo "  untagged version: id=$version_id name=$version_name"
+
+              if [ "$DRY_RUN" = "true" ]; then
+                continue
+              fi
+
+              if gh api --method DELETE "$versions_endpoint/$version_id"; then
+                deleted_versions=$((deleted_versions + 1))
+              else
+                echo "::warning::Failed to delete $package_name version $version_id"
+              fi
+            done < <(
+              gh api --paginate "$versions_endpoint" \
+                --jq '.[] | select(((.metadata.container.tags // []) | length) == 0) | [.id, .name] | @tsv'
+            )
+          done < <(
+            gh api --paginate "$api_base/packages?package_type=container" \
+              --jq '.[].name'
+          )
+
+          echo "Packages inspected: $total_packages"
+          echo "Packages matched: $matched_packages"
+          echo "Untagged versions found: $untagged_versions"
+          echo "Untagged versions deleted: $deleted_versions"
+
+          if [ "$DRY_RUN" = "true" ]; then
+            echo "Dry run only. Re-run with dry_run=false to delete these untagged versions."
+          fi

--- a/.github/workflows/onCodeChanges.yml
+++ b/.github/workflows/onCodeChanges.yml
@@ -575,6 +575,7 @@ jobs:
 
         - name: Clean untagged Ghcr.io images
           if: ${{ !cancelled() && (steps.push-sources-ghcr.outcome == 'success' || steps.push-binaries-ghcr.outcome == 'success') }}
+          continue-on-error: true
           uses: actions/delete-package-versions@v5
           with:
             package-name: ${{ env.REPOSITORY_NAME }}/${{ env.IMAGE_PREFIX }}${{ steps.get_args.outputs.PACKAGE_NAME }}
@@ -845,6 +846,7 @@ jobs:
 
         - name: Clean untagged Ghcr.io images
           if: ${{ !cancelled() && (steps.push-sources-ghcr.outcome == 'success' || steps.push-binaries-ghcr.outcome == 'success') }}
+          continue-on-error: true
           uses: actions/delete-package-versions@v5
           with:
             package-name: ${{ env.REPOSITORY_NAME }}/${{ env.IMAGE_PREFIX }}${{ steps.get_args.outputs.PACKAGE_NAME }}

--- a/.github/workflows/onCodeChanges.yml
+++ b/.github/workflows/onCodeChanges.yml
@@ -291,6 +291,9 @@ jobs:
 
     build_push:
       runs-on: [ubuntu-latest]
+      permissions:
+        contents: read
+        packages: write
       needs: check_files
       if: needs.check_files.outputs.superbuild_flag == 'true'
       strategy:
@@ -499,6 +502,7 @@ jobs:
                 then
                     tag_arg="--tag ${{env.DEFAULT_USER}}/\"$line"
                     img_name="\"$line"
+                    package_name="${line%%:*}"
                 fi
               fi
             done < ${{ steps.get_path.outputs.PATH }}/${{matrix.apps}}/conf_build.ini
@@ -508,6 +512,7 @@ jobs:
             echo "BIN_ARGS=$binaries_args" >> $GITHUB_OUTPUT
             echo "TAG_ARGS=$tag_arg" >> $GITHUB_OUTPUT
             echo "IMG_NAME=$img_name" >> $GITHUB_OUTPUT
+            echo "PACKAGE_NAME=$package_name" >> $GITHUB_OUTPUT
             echo "CMPL_SRC=$compile_sources" >> $GITHUB_OUTPUT
             echo "CMPL_BIN=$compile_binaries" >> $GITHUB_OUTPUT
             echo "demos_matrix=${demos_matrix[@]}" >> $GITHUB_OUTPUT
@@ -568,6 +573,15 @@ jobs:
           if: steps.get_args.outputs.CMPL_BIN == 'true'
           run: docker push ${{ env.REGISTRY }}/${{ env.REPOSITORY_NAME }}/${{ env.IMAGE_PREFIX }}${{ steps.get_args.outputs.IMG_NAME }}_binaries"
 
+        - name: Clean untagged Ghcr.io images
+          if: ${{ !cancelled() && (steps.push-sources-ghcr.outcome == 'success' || steps.push-binaries-ghcr.outcome == 'success') }}
+          uses: actions/delete-package-versions@v5
+          with:
+            package-name: ${{ env.REPOSITORY_NAME }}/${{ env.IMAGE_PREFIX }}${{ steps.get_args.outputs.PACKAGE_NAME }}
+            package-type: container
+            min-versions-to-keep: 0
+            delete-only-untagged-versions: 'true'
+
         # - name: Trigger testing pipeline for source image
         #   if: steps.build-sources.outcome == 'success' && steps.push-sources.outcome == 'success' && steps.get_args.outputs.demos_flag_output == 'true' && ! cancelled()
         #   uses: peter-evans/repository-dispatch@v3
@@ -593,6 +607,9 @@ jobs:
 
     build_push_custom:
       runs-on: [ubuntu-latest]
+      permissions:
+        contents: read
+        packages: write
       needs: check_files
       if: needs.check_files.outputs.custom_flag == 'true'
       strategy:
@@ -755,6 +772,7 @@ jobs:
                 then
                     tag_arg="--tag ${{env.DEFAULT_USER}}/\"$line"
                     img_name="\"$line"
+                    package_name="${line%%:*}"
                 fi
               fi
             done < ${{ steps.get_path.outputs.PATH }}/${{matrix.apps}}/conf_build.ini
@@ -764,6 +782,7 @@ jobs:
             echo "BIN_ARGS=$binaries_args" >> $GITHUB_OUTPUT
             echo "TAG_ARGS=$tag_arg" >> $GITHUB_OUTPUT
             echo "IMG_NAME=$img_name" >> $GITHUB_OUTPUT
+            echo "PACKAGE_NAME=$package_name" >> $GITHUB_OUTPUT
             echo "CMPL_SRC=$compile_sources" >> $GITHUB_OUTPUT
             echo "CMPL_BIN=$compile_binaries" >> $GITHUB_OUTPUT
             echo "demos_matrix=${demos_matrix[@]}" >> $GITHUB_OUTPUT
@@ -823,6 +842,15 @@ jobs:
           id: push-binaries-ghcr
           if: steps.get_args.outputs.CMPL_BIN == 'true'
           run: docker push ${{ env.REGISTRY }}/${{ env.REPOSITORY_NAME }}/${{ env.IMAGE_PREFIX }}${{ steps.get_args.outputs.IMG_NAME }}_binaries"
+
+        - name: Clean untagged Ghcr.io images
+          if: ${{ !cancelled() && (steps.push-sources-ghcr.outcome == 'success' || steps.push-binaries-ghcr.outcome == 'success') }}
+          uses: actions/delete-package-versions@v5
+          with:
+            package-name: ${{ env.REPOSITORY_NAME }}/${{ env.IMAGE_PREFIX }}${{ steps.get_args.outputs.PACKAGE_NAME }}
+            package-type: container
+            min-versions-to-keep: 0
+            delete-only-untagged-versions: 'true'
 
     trigger_children_build:
       runs-on: [ubuntu-latest]


### PR DESCRIPTION
This PR brings the following changes:
- add a workflow for cleaning manually the currently untagged images present in our organization packages (it let the user set a dry-run boolean in order to print the images that are going to be deleted)
- cleanup all new untagged images during each publishing so that we won't proliferate the organization with new untagged images

